### PR TITLE
Increase target Android version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,24 +1,24 @@
-apply plugin: 'com.android.application'
+plugins {
+  id 'com.android.application'
+}
 
 android {
-  compileSdkVersion 21
-  buildToolsVersion "21.1.1"
+  compileSdk 32
+  buildToolsVersion '30.0.3'
+  namespace 'com.ath0.rpn'
 
   defaultConfig {
-    applicationId "com.ath0.rpn"
-    minSdkVersion 15
-    targetSdkVersion 21
-    versionCode 1
-    versionName "1.0"
+    applicationId 'com.ath0.rpn'
+    minSdk 15
+    targetSdk 32
+    versionName '2.0.4'
+    versionCode 18
   }
   buildTypes {
     release {
-      runProguard false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      minifyEnabled false
+      proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
     }
   }
 }
 
-dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
-}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ath0.rpn"
-    android:installLocation="auto"
-    android:versionCode="18"
-    android:versionName="2.0.4" >
-
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="18" />
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.VIBRATE" />
 
@@ -18,7 +11,7 @@
         android:theme="@android:style/Theme" >
         <activity
             android:name=".Main"
-            android:label="@string/app_name"
+            android:exported="true"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.RPN" >
             <intent-filter>

--- a/app/src/main/java/com/ath0/rpn/Main.java
+++ b/app/src/main/java/com/ath0/rpn/Main.java
@@ -445,14 +445,14 @@ public class Main extends Activity implements OnKeyListener {
     if (clipboard.hasPrimaryClip()) {
       if (clipboard.getPrimaryClipDescription().hasMimeType(
           ClipDescription.MIMETYPE_TEXT_PLAIN)) {
-        Log.d("setMenuStateForClipboard", "Clipboard is OK");
+        Log.d("setMenuStateForClipbrd", "Clipboard is OK");
         pasteitem.setEnabled(true);
       } else {
-        Log.d("setMenuStateForClipboard", "Clipboard has no plain text");
+        Log.d("setMenuStateForClipbrd", "Clipboard has no plain text");
         pasteitem.setEnabled(false);
       }
     } else {
-      Log.d("setMenuStateForClipboard", "Clipboard is empty");
+      Log.d("setMenuStateForClipbrd", "Clipboard is empty");
       pasteitem.setEnabled(false);
     }
     return true;

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
-buildscript {
-  repositories {
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:0.13.2'
-
-    // NOTE: Do not place your application dependencies here; they belong
-    // in the individual module build.gradle files
-  }
-}
-
-allprojects {
-  repositories {
-    jcenter()
-  }
+plugins {
+  id 'com.android.application' version '7.2.2' apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Tue Aug 23 20:44:59 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,15 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 include ':app'


### PR DESCRIPTION
I recently had to replace my almost six year old Android phone to a newer version.
Starting my most favourite every day calculator app I'm now I'm constantly reminded that it's been compiled for an old Android version.
This PR includes the minimal changes to (mostly) the build scripts to make the app compile for newer Android versions, using a recent build tool version.

I've tested it on two virtual Emulator devices.